### PR TITLE
throw on objects and floats

### DIFF
--- a/romans.js
+++ b/romans.js
@@ -20,8 +20,8 @@ const allNumerals = Object.values(roman_map)
 const romanize = (decimal) => {
   if (
     decimal <= 0 ||
-    typeof decimal !== 'number' || // is number (e.g. not '1000' and not `{value: 1000}`)
-    Math.floor(decimal) !== decimal // is not float (e.g. 23.567)
+    typeof decimal !== 'number' ||
+    Math.floor(decimal) !== decimal
   ) {
     throw new Error('requires an unsigned integer')
   }

--- a/romans.js
+++ b/romans.js
@@ -20,8 +20,8 @@ const allNumerals = Object.values(roman_map)
 const romanize = (decimal) => {
   if (
     decimal <= 0 ||
-    typeof decimal === 'undefined' ||
-    typeof decimal === 'string'
+    typeof decimal !== 'number' || // is number (e.g. not '1000' and not `{value: 1000}`)
+    Math.floor(decimal) !== decimal // is not float (e.g. 23.567)
   ) {
     throw new Error('requires an unsigned integer')
   }

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -97,6 +97,16 @@ describe('should return errors on bad input', function () {
       romans.deromanize({ toUpperCase: function () { return 'III' } })
     }).toThrow()
   })
+  it('should reject objects', function () {
+    expect(function () {
+      romans.romanize({ value: 1000 })
+    }).toThrow()
+  })
+  it('should reject float values', function () {
+    expect(function () {
+      romans.romanize(567.789)
+    }).toThrow()
+  })
 })
 
 describe('it should return solid integer numbers', function () {


### PR DESCRIPTION
# Why?
- because `romans.romanize(567.678)` returns `DLXVIII` which is misleading
- because `romans.romanize({ value: 1000 })` returns empty string (which does not tell the developer about bad data flow in the code)
- I was just practicing TDD and came across roman numeral conversion problem, used your library to test my code. Then just decided to contribute :+1:   Thanks

## Note
And I'm also not sure if it accounts as breaking change or bug fix. So note the `version` field in `package.json` upon/after merge.