### PR TITLE
throw when input of deromanizer os not string

### DIFF
--- a/romans.js
+++ b/romans.js
@@ -36,6 +36,10 @@ const romanize = (decimal) => {
 }
 
 const deromanize = (romanStr) => {
+  if (typeof romanStr !== 'string') {
+    throw new Error('requires a string')
+  }
+
   let romanString = romanStr.toUpperCase()
   let arabic = 0
   let iteration = romanString.length

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -80,6 +80,23 @@ describe('should return errors on bad input', function () {
       romans.romanize('1000')
     }).toThrow()
   })
+  it('should reject non-string inputs for deromanizer', function () {
+    expect(function () {
+      romans.deromanize(1000)
+    }).toThrow()
+
+    expect(function () {
+      romans.deromanize({ value: 'III' })
+    }).toThrow()
+
+    expect(function () {
+      romans.deromanize(true)
+    }).toThrow()
+
+    expect(function () {
+      romans.deromanize({ toUpperCase: function () { return 'III' } })
+    }).toThrow()
+  })
 })
 
 describe('it should return solid integer numbers', function () {


### PR DESCRIPTION
# Why?
- because `romans.deromanize(1000)` throws `romanStr.toUpperCase is not a function` which in first sight does not seem meaningful for developer (`romanStr` is variable of this library and the developer may have never used `toUpperCase` at all, or if has used, may look in the wrong place for error)
- because `romans.deromanize({ toUpperCase: function () { return 'III' } })` returns `3` (which looks great on first sight, but actually does not inform developer of bad data flow in their code)
- because `romanStr.toUpperCase is not a function` is kinda un-controlled throw, but having it controlled feels more fun and accurate
- I was just practicing TDD and came across roman numeral conversion problem, used your library to test my code. Then just decided to contribute :+1:   Thanks

## Note
And I'm also not sure if it accounts as breaking change or bug fix. So note the `version` field in `package.json` upon/after merge.